### PR TITLE
Set up emacs daemon

### DIFF
--- a/config/emacs/aliases.zsh
+++ b/config/emacs/aliases.zsh
@@ -1,4 +1,4 @@
 #!/usr/bin/env zsh
 
-alias e='emacsclient -n'
+alias e='emacsclient -c'
 ediff() { e --eval "(ediff-files \"$1\" \"$2\")"; }

--- a/hosts/xps/default.nix
+++ b/hosts/xps/default.nix
@@ -49,7 +49,10 @@
     };
     editors = {
       default = "nvim";
-      emacs.enable = true;
+      emacs = {
+        enable = true;
+        daemon = true;
+      };
       vim.enable = true;
       vscode.enable = true;
     };

--- a/modules/editors/emacs.nix
+++ b/modules/editors/emacs.nix
@@ -10,6 +10,7 @@ let cfg = config.modules.editors.emacs;
 in {
   options.modules.editors.emacs = {
     enable = mkBoolOpt false;
+    daemon = mkBoolOpt false;
     doom = {
       enable = mkBoolOpt true;
       fromSSH = mkBoolOpt false;
@@ -19,7 +20,7 @@ in {
   config = mkIf cfg.enable {
     nixpkgs.overlays = [ inputs.emacs-overlay.overlay inputs.nur.overlay ];
 
-    services.emacs = {
+    services.emacs = mkIf cfg.daemon {
       enable = true;
       package = pkgs.emacsPgtkGcc;
       defaultEditor = true;

--- a/modules/editors/emacs.nix
+++ b/modules/editors/emacs.nix
@@ -19,6 +19,12 @@ in {
   config = mkIf cfg.enable {
     nixpkgs.overlays = [ inputs.emacs-overlay.overlay inputs.nur.overlay ];
 
+    services.emacs = {
+      enable = true;
+      package = pkgs.emacsPgtkGcc;
+      defaultEditor = true;
+    };
+
     user.packages = with pkgs; [
       ## Emacs itself
       binutils # native-comp needs 'as', provided by this


### PR DESCRIPTION
This sets up emacs in daemon mode; making it a configurable option that's off by default so that it doesn't run on lower power systems (I think it's clear that the performance difference is nontrivial).

Closes #28 